### PR TITLE
[feat] #4 - 현지역 기반 AI 키워드 장소 추천 기능 개선

### DIFF
--- a/src/maps/maps.service.ts
+++ b/src/maps/maps.service.ts
@@ -237,10 +237,36 @@ export class MapsService {
     // 추천 키워드 기반 외부 장소 검색 후 DB와 매칭
     async findNearbyMatchedAndExternalStores(keyword: string, lat: number, lng: number): Promise<{
         matchedStores: Store[],
-        externalPlaces: any[] // 또는 NaverPlaceDto 형식으로 타입 지정 가능
+        externalPlaces: any[]
     }> {
         const allStores = await this.storeRepository.find();
         const matched: Store[] = [];
+
+        // 지역명 가져오기
+        let regionName = '';
+        try {
+            const reverseResponse = await axios.get('https://maps.apigw.ntruss.com/map-reversegeocode/v2/gc', {
+                headers: {
+                    'X-NCP-APIGW-API-KEY-ID': this.MAP_CLIENT_ID,
+                    'X-NCP-APIGW-API-KEY': this.MAP_CLIENT_SECRET,
+                },
+                params: {
+                    coords: `${lng},${lat}`,
+                    orders: 'addr',
+                    output: 'json',
+                },
+            });
+
+            const region = reverseResponse.data.results[0]?.region;
+
+            regionName = region?.area3?.name || region?.area2?.name || ''; // 읍/면/구 수준으로만 사용
+        } catch (e) {
+            console.error('Reverse geocode 실패:', e.response?.data || e.message || e);
+            console.warn('지역명 가져오기 실패, 기본 키워드로 검색 진행');
+        }
+
+        // 지역명 포함한 쿼리 구성 (기존 keyword에 추가)
+        const query = regionName ? `${regionName} ${keyword}` : keyword;
 
         const response = await axios.get('https://openapi.naver.com/v1/search/local.json', {
             headers: {
@@ -248,16 +274,20 @@ export class MapsService {
                 'X-Naver-Client-Secret': this.MAP_SERVICE_SECRET,
             },
             params: {
-                query: keyword,
+                query,
                 display: 5,
-                sort: 'random'
+                sort: 'random',
             }
         });
 
         const items = response.data.items;
+        const externalPlaces = items.map(place => ({
+            ...place,
+            title: place.title.replace(/<[^>]*>/g, '').replace(/&amp;/g, '&').trim()
+        }));
 
-        for (const place of items) {
-            const title = place.title.replace(/<[^>]*>/g, '').trim();
+        for (const place of externalPlaces) {
+            const title = place.title;
             const phone = place.telephone?.replace(/[^0-9]/g, '');
 
             const match = allStores.find(store => {
@@ -276,8 +306,9 @@ export class MapsService {
 
         const result = {
             matchedStores: matched,
-            externalPlaces: items
+            externalPlaces,
         };
+
         console.log('최종 반환값:', result);
         return result;
     }


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #4 
<br/>


## 작업 내용
- Naver Reverse Geocoding API를 통해 현재 좌표 기준 지역명 추출
- 키워드 검색 시, 추출한 지역명을 키워드 앞에 자동으로 추가 (ex. "조치원 김밥")
- 기존 검색 로직은 그대로 유지하면서, 지역 정보를 반영하여 주변 가게 우선 노출
- 불필요한 HTML 태그와 &amp; 문자열 정제 처리 (<tag> 제거 및 치환)

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
